### PR TITLE
perf_#1_improve-the-compile-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This is a crate based on [Lucide](https://lucide.dev/) designed for Leptos front-end applications.
 
+> [leptos-icons](https://github.com/carloskiki/leptos-icons) has a better implementation, and it also contains Lucide icons. I recommend using it!
+
 ## Installation
 
 ```toml


### PR DESCRIPTION
### Prerequisite

_No response_

### Resolves

Resolves #1

### Description

I realized if based on `SVG` files and compile them onbuild, it can't ever be fast. Actually, the build process is pretty fast, but `rust-analyzer` takes a long time to deal with the output `Leptos` codes of those `SVG` components.

So, I recommend just using [`leptos-icons`](https://github.com/carloskiki/leptos-icons). Don't forget to give it a star 💫 !